### PR TITLE
Fix semPlotModel's mplusStd options

### DIFF
--- a/R/00classes.R
+++ b/R/00classes.R
@@ -99,7 +99,7 @@ semPlotModel.default <- function(object,...)
     head <- readLines(object, 10)
     if (any(grepl("mplus",head,ignore.case=TRUE)))
     {
-      return(semPlotModel.mplus.model(object))
+      return(semPlotModel.mplus.model(object,...))
     }
     
     if (any(grepl("l\\s*i\\s*s\\s*r\\s*e\\s*l",head,ignore.case=TRUE)))
@@ -112,7 +112,7 @@ semPlotModel.default <- function(object,...)
     mod <- try(semPlotModel_lavaanModel(object,...),silent=TRUE)
     if (!"try-error"%in%class(mod)) return(mod)
     
-    mod <- try(semPlotModel.mplus.model(object),silent=TRUE)
+    mod <- try(semPlotModel.mplus.model(object,...),silent=TRUE)
     if (!"try-error"%in%class(mod)) return(mod)
 
     mod <- try(semPlotModel(readLisrel(object)),silent=TRUE)

--- a/R/lists.R
+++ b/R/lists.R
@@ -1,7 +1,7 @@
 
-semPlotModel.list <- function(object, ...)
+semPlotModel.list <- function(object,...)
 {
-  if ("mplus.model"%in%class(object)) return(semPlotModel.mplus.model(object))
+  if ("mplus.model"%in%class(object)) return(semPlotModel.mplus.model(object,...))
   
   mod <- try(semPlotModel_lavaanModel(object,...),silent=TRUE)
   if (!"try-error"%in%class(mod)) return(mod)

--- a/R/mplus.R
+++ b/R/mplus.R
@@ -7,7 +7,7 @@
 
 readModels <- NULL
 
-semPlotModel.mplus.model <- function (object,mplusStd=c("std", "stdy", "stdxy"),...)
+semPlotModel.mplus.model <- function (object,mplusStd=c("std", "stdy", "stdyx"),...)
   {
   mplusStd <- match.arg(mplusStd)
 
@@ -128,18 +128,22 @@ semPlotModel.mplus.model <- function (object,mplusStd=c("std", "stdy", "stdxy"),
 #     Pars$std <- object$parameters$stdyx.standardized$est
 #   }
   
+                                 
   if (!is.null(object$parameters$std.standardized) && mplusStd == "std")
   {   
     Pars$std <- object$parameters$std.standardized$est
     # warning("Mplus std parameters will be plotted. To change that, use the modelOpts argument and set mplusStd to stdy, or stdyx parameters.")
-  }else if (!is.null(object$parameters$stdy.standardized) && mplusStd == "std"){
+  } else if (!is.null(object$parameters$stdy.standardized) && mplusStd == "stdy")
+  {
     Pars$std <- object$parameters$stdy.standardized$est
-  }else if (!is.null(object$parameters$stdyx.standardized)  && mplusStd == "std"){
+  } else if (!is.null(object$parameters$stdyx.standardized)  && mplusStd == "stdyx")
+  {
     Pars$std <- object$parameters$stdyx.standardized$est
+  } else if (!is.null(object$parameters$standardized))
+  {
+    Pars$std <- object$parameters$standardized$est
   }
   
-  
-    
   Pars$lhs[grepl(".BY$",parsUS$paramHeader)] <- gsub("\\.BY$","",parsUS$paramHeader[grepl(".BY$",parsUS$paramHeader)])
   Pars$edge[grepl(".BY$",parsUS$paramHeader)] <- "->"
     
@@ -153,10 +157,7 @@ semPlotModel.mplus.model <- function (object,mplusStd=c("std", "stdy", "stdxy"),
   Pars$lhs[grepl("Variances",parsUS$paramHeader)] <- Pars$rhs[grepl("Variances",parsUS$paramHeader)]
   Pars$edge[grepl("Variances",parsUS$paramHeader)] <- "<->"
   
-  Pars$edge[grepl("Means|Intercepts",parsUS$paramHeader)] <- "int"
-  
-  if (!is.null(object$parameters$standardized)) Pars$std <- object$parameters$standardized$est
-  
+  Pars$edge[grepl("Means|Intercepts",parsUS$paramHeader)] <- "int"  
   
   # Extract threshold model:
   Thresh <- Pars[grepl("Thresholds",parsUS$paramHeader),-(3:4)]

--- a/man/semPlotModel.Rd
+++ b/man/semPlotModel.Rd
@@ -32,7 +32,7 @@ Methods to read a SEM object and return a \code{\link{semPlotModel-class}} objec
 % \method{semPlotModel}{lavaan}(object)
 \method{semPlotModel}{lisrel}(object, \dots)
 % \method{semPlotModel}{semspec}(object)
-\method{semPlotModel}{mplus.model}(object, mplusStd = c("std", "stdy", "stdxy"), \dots)
+\method{semPlotModel}{mplus.model}(object, mplusStd = c("std", "stdy", "stdyx"), \dots)
 \method{semPlotModel}{sem}(object, \dots)
 \method{semPlotModel}{msem}(object, \dots)
 \method{semPlotModel}{msemObjectiveML}(object, \dots)


### PR DESCRIPTION
The mplusStd is currently not passed to the semPlotModel.mplus.model function by the semPlotModel class, resulting in the function to always return the "std" coefficients (default behavior).

This pull request fixes the issue by modifying the call for semPlotModel.mplus.model within the semPlotModel class constructor.

I also fixed the logic for the parameter selection in mplus.R. I also changed the "stdxy" option to "stdyx" because that's what Mplus uses and I updated the manual pages accordingly.