### PR TITLE
Try to fix ordered = TRUE

### DIFF
--- a/R/lavaan.R
+++ b/R/lavaan.R
@@ -100,15 +100,27 @@ setMethod("semPlotModel_S4",signature("lavaan"),function(object){
   names(semModel@ObsCovs) <- lavInspect(object, "group.label")
   for (i in 1:length(semModel@ObsCovs))
   {
-    rownames(semModel@ObsCovs[[i]]) <- colnames(semModel@ObsCovs[[i]]) <- lavaanNames(object, type="ov") #object@Data@ov.names[[i]]
+    if (lavInspect(object, "options")$conditional.x){
+      rownames(semModel@ObsCovs[[i]]) <- colnames(semModel@ObsCovs[[i]]) <- lavaanNames(object, type="ov.model") #object@Data@ov.names[[i]]
+    } else {
+      rownames(semModel@ObsCovs[[i]]) <- colnames(semModel@ObsCovs[[i]]) <- lavaanNames(object, type="ov") #object@Data@ov.names[[i]]
+    }
   }
   
-  semModel@ImpCovs <- lapply(lavTech(object, "implied"), "[[", "cov")
+  if (lavInspect(object, "options")$conditional.x){
+    semModel@ImpCovs <- lapply(lavTech(object, "implied"), "[[", "res.cov")
+  } else {
+    semModel@ImpCovs <- lapply(lavTech(object, "implied"), "[[", "cov")
+  }
   names(semModel@ImpCovs) <- lavInspect(object, "group.label") # object@Data@group.label
 
   for (i in 1:length(semModel@ImpCovs))
   {
-    rownames(semModel@ImpCovs[[i]]) <- colnames(semModel@ImpCovs[[i]]) <- lavaanNames(object, type="ov") 
+    if (lavInspect(object, "options")$conditional.x){
+      rownames(semModel@ImpCovs[[i]]) <- colnames(semModel@ImpCovs[[i]]) <- lavaanNames(object, type="ov.model") 
+    } else {
+      rownames(semModel@ImpCovs[[i]]) <- colnames(semModel@ImpCovs[[i]]) <- lavaanNames(object, type="ov") 
+    }
   }
   
   semModel@Computed <- TRUE


### PR DESCRIPTION
Dear Prof. Epskamp,

May I propose some changes to `semPlot`?

A post in the lavaan Google Group (https://groups.google.com/g/lavaan/c/xnOqMUbUYfY/m/aZUQo1MYAgAJ) led me to issue https://github.com/SachaEpskamp/semPlot/issues/40 .

The error occurred with `ordered = TRUE`. As one of the users pointed out, it is related to *lavaan.R* and `lavaanNames()`.

I am interested in this topic because I may also need to plot this kind of model. I took a look and it seems that you have already been working on this issue, which is related to the `conditional.x` option. The current error occurred due to two other matrices, `ImpCovs` and `ObsCovs`, which do not match the names retrieved `"ov"` and need to use `"ov.model"`, when `conditional.x` is TRUE.

This is an illustration of the error:

``` r
library(lavaan)
#> This is lavaan 0.6-19
#> lavaan is FREE software! Please report any bugs.
# library(semPlot)

mod_pop <-
"
m ~ .3 * x
y ~ .4 * m
"
dat <- simulateData(model = mod_pop,
                    sample.nobs = 1000,
                    seed = 2345)
dat$y <- ifelse(dat$y > mean(dat$y), 1, 0)
dat$m <- ifelse(dat$m > mean(dat$m), 1, 0)
head(dat)
#>   m y          x
#> 1 0 0 -1.2856876
#> 2 1 1 -0.5067523
#> 3 1 0  1.1251033
#> 4 1 1  0.3062505
#> 5 1 0 -1.6463903
#> 6 0 1 -0.9033056

mod <-
"
m ~ x
y ~ m
"
fit <- sem(mod,
           data = dat,
           ordered = c("y", "m"))

devtools::load_all("C:/GitHub/semPlot")
#> ℹ Loading semPlot
p0 <- semPlotModel(fit)
#> Error in dimnames(x) <- dn: length of 'dimnames' [2] not equal to array extent
```

<sup>Created on 2024-11-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I tried to fix this problem based on what you have done:

https://github.com/sfcheung/semPlot/commit/1ee4f3c929a6a8d07d0463a87a909ea4380133f9

It seems to work:

``` r
library(lavaan)
#> This is lavaan 0.6-19
#> lavaan is FREE software! Please report any bugs.
# library(semPlot)

mod_pop <-
"
m ~ .3 * x
y ~ .4 * m
"
dat <- simulateData(model = mod_pop,
                    sample.nobs = 1000,
                    seed = 2345)
dat$y <- ifelse(dat$y > mean(dat$y), 1, 0)
dat$m <- ifelse(dat$m > mean(dat$m), 1, 0)
head(dat)
#>   m y          x
#> 1 0 0 -1.2856876
#> 2 1 1 -0.5067523
#> 3 1 0  1.1251033
#> 4 1 1  0.3062505
#> 5 1 0 -1.6463903
#> 6 0 1 -0.9033056

mod <-
"
m ~ x
y ~ m
"
fit <- sem(mod,
           data = dat,
           ordered = c("y", "m"))

devtools::load_all("C:/GitHub/semPlot")
#> ℹ Loading semPlot
p0 <- semPlotModel(fit)
semPaths(p0)
```

![](https://i.imgur.com/u9jIoJX.png)<!-- -->

<sup>Created on 2024-11-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I am not sure whether these changes will break other things. If it will, I can try to see how to fix them.

Feel free to reject this PR if it does not fit your plan.

Thanks again for developing this package for SEM users.

-- Shu Fai